### PR TITLE
avoid NoneType AttributeError with empty fields

### DIFF
--- a/brazilfiscalreport/danfe/danfe_basic_field.py
+++ b/brazilfiscalreport/danfe/danfe_basic_field.py
@@ -72,7 +72,7 @@ class DanfeBasicField(Element):
         self._content_lines = pdf.multi_cell(
             w=self.w,
             h=DEFAULT_HEIGHT_FONT_CONTENT,
-            text=self.content,
+            text=self.content or "",
             align=align,
             output=MethodReturnValue.LINES,
         )


### PR DESCRIPTION
More specifically avoid:
'NoneType' object has no attribute 'encode'
in normalize_text in fpdf/fpdf.py:4342

This fixes errors like I had in my nfelib tests with:
https://github.com/akretion/nfelib/actions/runs/9001971049/job/24729276315?pr=101#step:6:182
it looks like in this test NFe xml I had an empty time_ent_sai.
I think we should be lenient with such empty fields and this is what this PR does.