### PR TITLE
Fix page_lines

### DIFF
--- a/brazilfiscalreport/dacte/dacte.py
+++ b/brazilfiscalreport/dacte/dacte.py
@@ -68,6 +68,7 @@ class Dacte(xFPDF):
             )
             self.obs_dacte_list.append(self.x_texto)
 
+        self.page_lines = 0
         self.inf_carga_list = []
         for infQ in self.inf_carga:
             self.c_unid = extract_text(infQ, "cUnid")


### PR DESCRIPTION
## Objetivo da PR 

Correção de quando não tiver a tag infDoc no XML, como ela é somente inicializada quando ter informação no inf_doc_list que vem do infDoc dava error

![image](https://github.com/user-attachments/assets/04e55f78-0935-478e-bf5b-be6b83cf4e92)
