### PR TITLE
chore: force to use minimum version for fpdf2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "fpdf2",
+    "fpdf2>=2.8.3",
     "phonenumbers",
     "python-barcode"
 ]


### PR DESCRIPTION
**Problem:**
When updating BrazilFiscalReport to the latest version (0.5.22), the dependency fpdf2 were not updated automaticaly.

fpdf2 remained in the old version.

**Purpose of the change:**
force to use ">=2.8.3" for fpdf2, ensuring that you always get the latest version of fpdf2 or at least 2.8.3, which is the one that works.