### PR TITLE
BrazilFiscalReport: Versão

### DIFF
--- a/brazilfiscalreport/cli.py
+++ b/brazilfiscalreport/cli.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import click
 import yaml
 
+from brazilfiscalreport import __version__
+
 
 def load_config():
     try:
@@ -28,6 +30,9 @@ def get_default_issuer():
 
 
 @click.group()
+@click.version_option(
+    __version__, "-v", "--version", message="bfrep version %(version)s"
+)
 def cli():
     pass
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,8 @@
 
 Generate DACTE, DANFE, and DACCE documents directly from the terminal. The PDF will be saved in the current directory, and you'll need to create a config.yaml file with issuer details and other configurations.
 
+Use the --version or -v option to check the installed version.
+
 #### Example of `config.yaml` ⚙️
 
 ```yaml


### PR DESCRIPTION
## Objetivo da PR

Obter a versão da lib através do comando -v e --version

![image](https://github.com/user-attachments/assets/712b2908-95fc-42c9-93bf-ca791fd18eed)

Acabei usando aqui de exemplo pra ficar bem simples -> https://github.com/cookiecutter/cookiecutter/blob/b4451231809fb9e4fc2a1e95d433cb030e4b9e06/cookiecutter/cli.py#L88

@antoniospneto 
A mensagem pode deixar versão em português ou seria melhor em inglês?