### PR TITLE
docs: improve discoverability with PT keywords and expanded metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Python library for generating Brazilian auxiliary fiscal documents in PDF from XML documents.
 
+> Biblioteca Python para gerar **DANFE**, **DACTE**, **DAMDFE**, **DACCe** e **DANFSE** em PDF a partir de XML de NF-e, CT-e, MDF-e, CC-e e NFS-e.
+
 **[Documentation](https://engenere.github.io/BrazilFiscalReport/)** | **[PyPI](https://pypi.org/project/BrazilFiscalReport/)** | **[Try it Online](https://brazilfiscalreport.streamlit.app)**
 
 ## Supported Documents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ dynamic = ["version"]
 description = "Python library for generating Brazilian auxiliary fiscal documents in PDF from XML documents."
 authors = [{ name = "Engenere" }]
 keywords = [
-    "nfe", "danfe", "xml", "pdf", "documento", "fiscal", "auxiliar", "converter", "generator", "cce", "dacce", "danfse"
+    "nfe", "nf-e", "danfe", "cte", "ct-e", "dacte", "mdfe", "mdf-e", "damdfe",
+    "cce", "cc-e", "dacce", "nfse", "nfs-e", "danfse",
+    "xml", "pdf", "sefaz", "brazil", "brasil", "nota-fiscal-eletronica",
+    "documento", "fiscal", "auxiliar", "converter", "generator"
 ]
 license = { file = "LICENSE" }
 classifiers = [


### PR DESCRIPTION
## Summary
- Add Portuguese tagline to README listing all supported document types (DANFE, DACTE, DAMDFE, DACCe, DANFSE) — captures search traffic in PT-BR.
- Expand `pyproject.toml` keywords with hyphenated and non-hyphenated forms (NF-e/nfe, CT-e/cte, MDF-e/mdfe, CC-e/cce, NFS-e/nfse) plus `sefaz`, `brazil`, `brasil`, `nota-fiscal-eletronica` — improves PyPI search matching.
- Repo description and topics on GitHub were updated separately via API (now 20 topics including `nfe`, `nfse`, `cte`, `mdfe`, `python`, `pdf`, `xml`, `sefaz`, `brazil`, `nota-fiscal-eletronica`).

## Motivation
Searches like `danfe`, `danfe python`, `nfe python`, `nota fiscal eletronica` were not surfacing the project despite it being relevant. Root causes: hyphenated topics don't match unhyphenated queries, descriptions/keywords lacked the actual sigla acronyms, and README was English-only.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `pyproject.toml` is still valid (`pip install .` or `python -m build`)