### PR TITLE
xFPDF: muda core_fonts_encoding para cp1252

### DIFF
--- a/brazilfiscalreport/xfpdf.py
+++ b/brazilfiscalreport/xfpdf.py
@@ -2,6 +2,10 @@ from fpdf import FPDF
 
 
 class xFPDF(FPDF):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.core_fonts_encoding = "cp1252"
+
     def long_field(self, text="", limit=0, font_size=None, font_style=""):
         if not text or limit <= 0:
             return ""

--- a/tests/test_xfpdf.py
+++ b/tests/test_xfpdf.py
@@ -1,0 +1,33 @@
+import pytest
+
+from brazilfiscalreport.xfpdf import xFPDF
+
+# Caracteres tipográficos comuns em texto colado do Word/email que existem em
+# cp1252 (WinAnsiEncoding) mas NÃO em latin-1, e portanto quebravam o pipeline
+# de encoding das core fonts do fpdf2 com seu default ("latin-1").
+# Regression guard para o bug reportado em issue #162.
+CP1252_TYPOGRAPHIC_CHARS = [
+    "–",  # en-dash –
+    "—",  # em-dash —
+    "‘",  # left single quote ‘
+    "’",  # right single quote ’
+    "“",  # left double quote “
+    "”",  # right double quote ”
+    "…",  # horizontal ellipsis …
+    "•",  # bullet •
+    " ",  # non-breaking space
+    "€",  # euro sign €
+    "™",  # trademark sign ™
+]
+
+
+@pytest.mark.parametrize("char", CP1252_TYPOGRAPHIC_CHARS)
+def test_xfpdf_renders_cp1252_chars_with_core_font(char):
+    pdf = xFPDF()
+    pdf.add_page()
+    pdf.set_font("Times", "", 12)
+    pdf.cell(w=100, h=8, text=f"x{char}y")
+
+
+def test_xfpdf_core_fonts_encoding_is_cp1252():
+    assert xFPDF().core_fonts_encoding == "cp1252"


### PR DESCRIPTION
## Resumo

O fpdf2 usa `core_fonts_encoding="latin-1"` por padrão. **Latin-1 (ISO-8859-1) não cobre vários caracteres tipográficos que aparecem em texto colado de Word/email** — en-dash `–`, em-dash `—`, aspas curvas `" " ' '`, reticências `…`, bullet `•`, NBSP `\xa0`, € `€`, ™ `™`, etc. (a faixa `0x80–0x9F` do Latin-1 é ocupada por caracteres de controle invisíveis).

Quando qualquer um desses chega num campo de texto livre (ex.: `xDescServ`, `xNome`, `infCpl`), o fpdf2 levanta `FPDFUnicodeEncodingException` e quebra a geração do PDF.

Esse PR muda o encoding para **cp1252 (WinAnsiEncoding)**, que é superset estrito do Latin-1 e cobre todos esses caracteres.

Refs: #162

## Por que cp1252

- **Superset estrito do latin-1** — nada que renderizava antes deixa de renderizar.
- **É o mesmo encoding usado pelo gerador oficial de DANFSE do SERPRO** (confirmado via `pdffonts` em 10 DANFSE oficiais: todos com `encoding=WinAnsi`, fonte Segoe WP TrueType embarcada). Ou seja, esta mudança coloca a biblioteca em **paridade de cobertura de caracteres com o gerador oficial**.
- **Portável** — codec da stdlib do Python (tabela em memória, igual em Linux/macOS/Windows). `WinAnsiEncoding` está na spec PDF (ISO 32000), todo leitor tem hard-coded. Não introduz dependência de fonte ou de SO.
- **Sem custo** — não embarca fonte, não muda tamanho do PDF.

## Escopo

A mudança fica no `xFPDF` (base compartilhada) e beneficia todos os tipos de documento que herdam dele: **DANFE, DANFSE, DACTE, DAMDFE, DACCE**.

## Diff

```python
class xFPDF(FPDF):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.core_fonts_encoding = "cp1252"
```

## Testes

- Adicionado `tests/test_xfpdf.py` com regression guard parametrizado cobrindo 11 caracteres tipográficos que antes disparavam a exceção.
- Validação por controle negativo: sem o fix, 10 dos 11 testes falham (o único que passa é o NBSP `\xa0`, que coincide com Latin-1 — comportamento esperado).
- Suite completa: **70/70 passando** (58 anteriores + 12 novos).

## Test plan

- [x] Testes novos passam (`pytest tests/test_xfpdf.py`)
- [x] Suite completa passa (`pytest tests/ --ignore=tests/test_cli.py`)
- [x] Controle negativo: testes falham sem o fix (confirma que pegam a regressão)
- [x] Erro original do #162 reproduzido com FPDF puro (confirma que o fix corrige a causa-raiz)
- [x] `pdftotext` recupera os caracteres literais do PDF gerado (não viram `?`)