### PR TITLE
dacte: recorta textos longos e agrega componentes excedentes

### DIFF
--- a/brazilfiscalreport/dacte/dacte.py
+++ b/brazilfiscalreport/dacte/dacte.py
@@ -43,6 +43,14 @@ def extract_text(node: Element, tag: str) -> str:
     return get_tag_text(node, URL, tag)
 
 
+def to_float(value: str) -> float:
+    """Converte valor numérico cru do XML, tolerando ausência/formato inválido."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 class Dacte(xFPDF):
     def __init__(self, xml, config: DacteConfig = None):
         super().__init__(unit="mm", format="A4")
@@ -357,7 +365,18 @@ class Dacte(xFPDF):
             w_text = w_rect - 4
         self.set_font(self.default_font, "B", 9)
         self.set_xy(x=x_text, y=y_text)
-        self.multi_cell(w=w_text, h=5, text=self.emit_name, border=0, align="C")
+        # O endereço abaixo é desenhado em Y fixo (y_text + 6), ou seja, só há uma
+        # linha de 5 mm reservada para o nome. Razão social longa quebrava em duas
+        # linhas e a segunda saía por cima da linha "CNPJ: ... IE: ...".
+        self.multi_cell(
+            w=w_text,
+            h=5,
+            text=self.long_field(
+                text=self.emit_name, limit=w_text, font_size=9, font_style="B"
+            ),
+            border=0,
+            align="C",
+        )
         self.set_font(self.default_font, "", 8)
         self.set_xy(x=x_text - 3, y=y_text + 6)
         self.multi_cell(w=w_text + 10, h=3, text=address, border=0, align="C")
@@ -1347,9 +1366,16 @@ class Dacte(xFPDF):
             self.cell(w=col_width / 2, h=4, text=titles[1], align="L")
 
         # Distribuir os componentes em 3 colunas com 3 linhas cada
-        col1 = self.comp_list[:3]  # Primeiros 3 componentes
-        col2 = self.comp_list[3:6]  # Próximos 3 componentes
-        col3 = self.comp_list[6:9]  # Últimos 3 componentes
+        comp_list = self.comp_list
+        # O bloco comporta no máximo 9 linhas; do 10º componente em diante o valor
+        # era simplesmente descartado, sem aviso. Agrega o excedente em "OUTROS"
+        # para que a soma exibida continue correspondendo ao que o XML declara.
+        if len(comp_list) > 9:
+            outros = sum(to_float(valor) for _, valor in comp_list[8:])
+            comp_list = comp_list[:8] + [("OUTROS", f"{outros:.2f}")]
+        col1 = comp_list[:3]  # Primeiros 3 componentes
+        col2 = comp_list[3:6]  # Próximos 3 componentes
+        col3 = comp_list[6:9]  # Últimos 3 componentes
 
         # Altura inicial para começo dos dados
         data_y = section_start_y + 6
@@ -1359,7 +1385,14 @@ class Dacte(xFPDF):
             current_y = data_y
             for comp in components:
                 self.set_xy(x_start, current_y)
-                self.cell(w=col_width / 2, h=4, text=comp[0], align="L")
+                # cell() não recorta nem quebra: nome largo invadia a coluna do
+                # valor, desenhada logo ao lado em posição absoluta.
+                self.cell(
+                    w=col_width / 2,
+                    h=4,
+                    text=self.long_field(text=comp[0], limit=col_width / 2),
+                    align="L",
+                )
                 self.set_xy(x_start + col_width / 2, current_y)
                 self.cell(w=col_width / 2, h=4, text=comp[1], align="L")
                 current_y += 4  # Incrementa a posição Y para o próximo item

--- a/tests/test_dacte_overflow.py
+++ b/tests/test_dacte_overflow.py
@@ -1,0 +1,112 @@
+"""Textos longos no DACTE não podem invadir o campo vizinho.
+
+O layout do DACTE é de posição absoluta: o endereço do emitente e o valor de cada
+componente são desenhados em coordenadas fixas. Sem recorte, um texto mais largo
+que a coluna é escrito por cima do vizinho e o PDF sai ilegível nesse ponto.
+
+Estes testes renderizam o PDF e leem de volta as posições do texto — medem o
+resultado, e não a chamada de um helper.
+"""
+
+import re
+import zlib
+
+import pytest
+
+from brazilfiscalreport.dacte import Dacte
+
+# 60 caracteres = limite de xNome no leiaute do CT-e.
+RAZAO_SOCIAL_LONGA = "TRANSPORTADORA RODOVIARIA DE CARGAS GERAIS DO BRASIL SA ME"
+
+
+def textos_posicionados(pdf_bytes):
+    """[(y, x, texto)] de cada trecho desenhado, lendo o content stream do PDF."""
+    achados = []
+    for bruto in re.findall(rb"stream\r?\n(.*?)endstream", pdf_bytes, re.S):
+        try:
+            fluxo = zlib.decompress(bruto.strip(b"\r\n")).decode("latin-1")
+        except zlib.error:
+            continue
+        for td_x, td_y, texto in re.findall(
+            r"([\d.-]+)\s+([\d.-]+)\s+Td\s*\((.*?)\)\s*Tj", fluxo
+        ):
+            achados.append((round(float(td_y), 2), round(float(td_x), 2), texto))
+    return achados
+
+
+def mesma_linha(a, b, tolerancia=0.5):
+    """Dois trechos partilham a baseline (a menos de `tolerancia`)?"""
+    return abs(a[0] - b[0]) < tolerancia
+
+
+@pytest.fixture
+def xml_dacte(load_xml):
+    return load_xml("dacte/dacte_test_1.xml")
+
+
+def test_razao_social_longa_nao_escreve_por_cima_do_cnpj(xml_dacte):
+    """O endereço é desenhado em Y fixo logo abaixo do nome.
+
+    Se o nome ocupar duas linhas, a segunda cai exatamente sobre a linha
+    "CNPJ: ... IE: ...", deixando ambas ilegíveis.
+    """
+    xml = xml_dacte.replace(
+        "<xNome>FANTASMA TRANSPORTES LTDA</xNome>",
+        f"<xNome>{RAZAO_SOCIAL_LONGA}</xNome>",
+        1,
+    )
+    trechos = textos_posicionados(bytes(Dacte(xml=xml).output()))
+
+    linhas_cnpj = [t for t in trechos if t[2].startswith("CNPJ:")]
+    assert linhas_cnpj, "linha do CNPJ do emitente não encontrada no PDF"
+
+    for cnpj in linhas_cnpj:
+        vizinhos = [t for t in trechos if t is not cnpj and mesma_linha(t, cnpj)]
+        assert not vizinhos, f"texto sobreposto à linha do CNPJ: {vizinhos}"
+
+
+def test_nome_de_componente_longo_nao_invade_a_coluna_do_valor(xml_dacte):
+    """"OUTROS VALORES" mede 25,01 mm; a coluna do nome tem 21,75 mm úteis."""
+    xml = re.sub(
+        r"<Comp>\s*<xNome>[^<]*</xNome>",
+        "<Comp><xNome>OUTROS VALORES</xNome>",
+        xml_dacte,
+        count=1,
+    )
+    dacte = Dacte(xml=xml)
+    trechos = textos_posicionados(bytes(dacte.output()))
+
+    # O nome sai recortado ("OUTROS VAL..."), então procura-se pelo prefixo.
+    nomes = [t for t in trechos if t[2].startswith("OUTROS")]
+    assert nomes, "componente 'OUTROS VALORES' não encontrado no PDF"
+
+    dacte.set_font(dacte.default_font, "", 8)
+    largura_coluna_nome = ((dacte.epw - 10) / 4) / 2  # col_width / 2
+
+    for nome in nomes:
+        largura = dacte.get_string_width(nome[2])
+        assert largura <= largura_coluna_nome, (
+            f"'{nome[2]}' ocupa {largura:.2f} mm numa coluna de "
+            f"{largura_coluna_nome:.2f} mm — invade o valor à direita"
+        )
+
+
+def test_componentes_alem_do_nono_aparecem_agregados(xml_dacte):
+    """O bloco comporta 9 linhas; o excedente vira "OUTROS" em vez de sumir."""
+    doze = "".join(
+        f"<Comp><xNome>COMP {i}</xNome><vComp>{i * 10}.00</vComp></Comp>"
+        for i in range(1, 13)
+    )
+    xml = re.sub(r"<Comp>.*</Comp>", doze, xml_dacte, count=1, flags=re.S)
+    texto = " ".join(t[2] for t in textos_posicionados(bytes(Dacte(xml=xml).output())))
+
+    assert "OUTROS" in texto, "o excedente de componentes sumiu do PDF"
+
+
+def test_to_float_tolera_valor_ausente_ou_invalido():
+    from brazilfiscalreport.dacte.dacte import to_float
+
+    assert to_float("12.34") == 12.34
+    assert to_float("") == 0.0
+    assert to_float(None) == 0.0
+    assert to_float("R$ 10") == 0.0


### PR DESCRIPTION
## Problema

O layout do DACTE desenha em posição absoluta, e alguns campos não recortam o texto. Quando o conteúdo é mais largo que a coluna, ele é escrito **por cima do campo vizinho** — o PDF fica ilegível naquele ponto.

Três situações, todas em CT-e válido (nenhuma depende de XML fora do leiaute):

### 1. Razão social longa do emitente cobre a linha do CNPJ

O nome é desenhado com `multi_cell(h=5)`, que quebra linha, mas o endereço logo abaixo é ancorado num **Y fixo** (`y_text + 6`) — ou seja, só há uma linha de 5 mm reservada:

https://github.com/Engenere/BrazilFiscalReport/blob/main/brazilfiscalreport/dacte/dacte.py#L358-L363

Com um `xNome` de 39 caracteres, a segunda linha do nome cai exatamente sobre a linha `CNPJ: ... IE: ...`:

```
RODONAVES TRANSPORTES E
CNPJ: ENCOMENDAS LTDA82533118      <- nome e CNPJ sobrepostos
```

Vale notar que **todos os outros nomes do próprio DACTE já são recortados** — `rem_nome` (`limit_text(..., 48)`), `dest_nome`, `receb_nome`, `exped_nome`, `tomador_nome` (38) — e o DANFE faz o mesmo em `danfe.py` com `long_field(limit=60)`. O emitente ficou de fora.

### 2. Nome de componente invade a coluna do valor

Na seção "COMPONENTES DO VALOR DA PRESTAÇÃO DO SERVIÇO", o `xNome` é escrito com `cell()` numa coluna de `col_width / 2`. O `cell()` não recorta nem quebra:

```
OUTROS VALORES331.77      <- nome e valor colados
```

Medindo: `col_width/2` = 23,75 mm, menos `2 × c_margin` do fpdf2 = **21,75 mm úteis**; `"OUTROS VALORES"` em Times 8 mede **25,01 mm**. Sobra 1,26 mm por cima do primeiro dígito do valor.

`xNome` de `Comp` é texto livre preenchido pelo emitente, então nomes largos são comuns na prática.

### 3. Do 10º componente em diante, o valor some do PDF

A distribuição é fixa em 3 colunas × 3 linhas (`comp_list[:3]`, `[3:6]`, `[6:9]`). O que passa disso não é desenhado — sem aviso, e sem que a soma exibida corresponda ao que o XML declara.

## O que muda

- **(1) e (2)**: passam a usar `long_field` — o mesmo recorte por largura medida já usado no DANFE e nos demais nomes do DACTE. Nenhum helper novo.
- **(3)**: o excedente é agregado numa linha `OUTROS`, preservando a soma. Um helper local `to_float` tolera valor ausente/malformado.

Nada disso muta `self.emit_name` nem `self.comp_list` — só o texto renderizado.

**O item (3) é a parte mais opinativa deste PR.** Agregar em "OUTROS" me pareceu melhor que descartar em silêncio, mas se vocês preferirem outra saída (reduzir a fonte, paginar o bloco, ou simplesmente documentar o limite), fico à vontade para ajustar.

## Testes

Novo arquivo `tests/test_dacte_overflow.py`. Os testes **renderizam o PDF e leem de volta as posições do texto** do content stream, em vez de checar a chamada de um helper — assim medem o resultado e continuam válidos se a implementação mudar:

- `test_razao_social_longa_nao_escreve_por_cima_do_cnpj` — nenhum texto pode partilhar a baseline da linha do CNPJ.
- `test_nome_de_componente_longo_nao_invade_a_coluna_do_valor` — a largura renderizada do nome tem de caber na coluna.
- `test_componentes_alem_do_nono_aparecem_agregados` — com 12 componentes, "OUTROS" aparece no PDF.
- `test_to_float_tolera_valor_ausente_ou_invalido`.

Verifiquei que eles **falham** sem a correção. O primeiro aponta o texto exato que sobrepõe:

```
AssertionError: texto sobreposto à linha do CNPJ:
  [(735.73, 30.75, 'CARGAS GERAIS DO BRASIL SA ME')]
```

## PDFs de referência

**Inalterados.** Nenhuma das 13 fixtures de DACTE tem razão social maior que 28 caracteres nem componente com nome largo — que é justamente por que os testes golden nunca pegaram isto. Suíte completa: **96 passed**.
