### PR TITLE
DACTE: recorta textos longos que invadem campos vizinhos

### DIFF
--- a/brazilfiscalreport/dacte/dacte.py
+++ b/brazilfiscalreport/dacte/dacte.py
@@ -357,7 +357,18 @@ class Dacte(xFPDF):
             w_text = w_rect - 4
         self.set_font(self.default_font, "B", 9)
         self.set_xy(x=x_text, y=y_text)
-        self.multi_cell(w=w_text, h=5, text=self.emit_name, border=0, align="C")
+        # O endereço abaixo é desenhado em Y fixo (y_text + 6), ou seja, só há uma
+        # linha de 5 mm reservada para o nome. Razão social longa quebrava em duas
+        # linhas e a segunda saía por cima da linha "CNPJ: ... IE: ...".
+        self.multi_cell(
+            w=w_text,
+            h=5,
+            text=self.long_field(
+                text=self.emit_name, limit=w_text, font_size=9, font_style="B"
+            ),
+            border=0,
+            align="C",
+        )
         self.set_font(self.default_font, "", 8)
         self.set_xy(x=x_text - 3, y=y_text + 6)
         self.multi_cell(w=w_text + 10, h=3, text=address, border=0, align="C")
@@ -1359,7 +1370,16 @@ class Dacte(xFPDF):
             current_y = data_y
             for comp in components:
                 self.set_xy(x_start, current_y)
-                self.cell(w=col_width / 2, h=4, text=comp[0], align="L")
+                # cell() não recorta nem quebra: nome largo invadia a coluna do
+                # valor, desenhada logo ao lado em posição absoluta.
+                self.cell(
+                    w=col_width / 2,
+                    h=4,
+                    text=self.long_field(
+                        text=comp[0], limit=col_width / 2, font_size=8
+                    ),
+                    align="L",
+                )
                 self.set_xy(x_start + col_width / 2, current_y)
                 self.cell(w=col_width / 2, h=4, text=comp[1], align="L")
                 current_y += 4  # Incrementa a posição Y para o próximo item

--- a/tests/test_dacte_overflow.py
+++ b/tests/test_dacte_overflow.py
@@ -1,0 +1,95 @@
+"""Textos longos no DACTE não podem invadir o campo vizinho.
+
+O layout do DACTE é de posição absoluta: o endereço do emitente e o valor de cada
+componente são desenhados em coordenadas fixas. Sem recorte, um texto mais largo
+que a coluna é escrito por cima do vizinho e o PDF sai ilegível nesse ponto.
+
+Estes testes renderizam o PDF e leem de volta as posições do texto — medem o
+resultado, e não a chamada de um helper.
+"""
+
+import re
+import zlib
+
+import pytest
+
+from brazilfiscalreport.dacte import Dacte
+
+# 60 caracteres = limite de xNome no leiaute do CT-e.
+RAZAO_SOCIAL_LONGA = "TRANSPORTADORA RODOVIARIA DE CARGAS GERAIS DO BRASIL SA ME"
+
+
+def textos_posicionados(pdf_bytes):
+    """[(y, x, texto)] de cada trecho desenhado, lendo o content stream do PDF."""
+    achados = []
+    for bruto in re.findall(rb"stream\r?\n(.*?)endstream", pdf_bytes, re.S):
+        try:
+            fluxo = zlib.decompress(bruto.strip(b"\r\n")).decode("latin-1")
+        except zlib.error:
+            continue
+        for td_x, td_y, texto in re.findall(
+            r"([\d.-]+)\s+([\d.-]+)\s+Td\s*\((.*?)\)\s*Tj", fluxo
+        ):
+            achados.append((round(float(td_y), 2), round(float(td_x), 2), texto))
+    return achados
+
+
+def mesma_linha(a, b, tolerancia=0.5):
+    """Dois trechos partilham a baseline (a menos de `tolerancia`)?"""
+    return abs(a[0] - b[0]) < tolerancia
+
+
+@pytest.fixture
+def xml_dacte(load_xml):
+    return load_xml("dacte/dacte_test_1.xml")
+
+
+def test_razao_social_longa_nao_escreve_por_cima_do_cnpj(xml_dacte):
+    """O endereço é desenhado em Y fixo logo abaixo do nome.
+
+    Se o nome ocupar duas linhas, a segunda cai exatamente sobre a linha
+    "CNPJ: ... IE: ...", deixando ambas ilegíveis.
+    """
+    xml = xml_dacte.replace(
+        "<xNome>FANTASMA TRANSPORTES LTDA</xNome>",
+        f"<xNome>{RAZAO_SOCIAL_LONGA}</xNome>",
+        1,
+    )
+    trechos = textos_posicionados(bytes(Dacte(xml=xml).output()))
+
+    linhas_cnpj = [t for t in trechos if t[2].startswith("CNPJ:")]
+    assert linhas_cnpj, "linha do CNPJ do emitente não encontrada no PDF"
+
+    for cnpj in linhas_cnpj:
+        vizinhos = [t for t in trechos if t is not cnpj and mesma_linha(t, cnpj)]
+        assert not vizinhos, f"texto sobreposto à linha do CNPJ: {vizinhos}"
+
+
+def test_nome_de_componente_longo_nao_invade_a_coluna_do_valor(xml_dacte):
+    """Nome de componente largo é escrito por cima do valor à direita.
+
+    "OUTROS VALORES" mede 25,01 mm; a coluna do nome tem 21,75 mm úteis.
+    """
+    xml = re.sub(
+        r"<Comp>\s*<xNome>[^<]*</xNome>",
+        "<Comp><xNome>OUTROS VALORES</xNome>",
+        xml_dacte,
+        count=1,
+    )
+    dacte = Dacte(xml=xml)
+    trechos = textos_posicionados(bytes(dacte.output()))
+
+    # O nome sai recortado ("OUTROS VAL..."), então procura-se pelo prefixo.
+    nomes = [t for t in trechos if t[2].startswith("OUTROS")]
+    assert nomes, "componente 'OUTROS VALORES' não encontrado no PDF"
+
+    dacte.set_font(dacte.default_font, "", 8)
+    col_width = (dacte.epw - 2 * dacte.l_margin) / 4
+    largura_coluna_nome = col_width / 2
+
+    for nome in nomes:
+        largura = dacte.get_string_width(nome[2])
+        assert largura <= largura_coluna_nome, (
+            f"'{nome[2]}' ocupa {largura:.2f} mm numa coluna de "
+            f"{largura_coluna_nome:.2f} mm — invade o valor à direita"
+        )


### PR DESCRIPTION
Primeira metade da #186, de @andmit10 — os dois recortes de texto, que não dependem de nenhuma decisão de layout. A agregação de componentes excedentes foi separada na #191.

## Problema

O layout do DACTE desenha em posição absoluta e alguns campos não recortam o texto. Quando o conteúdo é mais largo que a coluna, ele é escrito **por cima do campo vizinho**.

**1. Razão social longa do emitente cobre a linha do CNPJ.** O nome é desenhado com `multi_cell(h=5)`, que quebra linha, mas o endereço logo abaixo é ancorado num Y fixo (`y_text + 6`) — só há uma linha de 5 mm reservada. A segunda linha do nome cai exatamente sobre `CNPJ: ... IE: ...`:

```
RODONAVES TRANSPORTES E
CNPJ: ENCOMENDAS LTDA82533118      <- nome e CNPJ sobrepostos
```

**2. Nome de componente invade a coluna do valor.** Na seção "COMPONENTES DO VALOR DA PRESTAÇÃO DO SERVIÇO" o `xNome` é escrito com `cell()`, que não recorta nem quebra. A coluna tem `col_width/2` = 23,75 mm, menos `2 × c_margin` = **21,75 mm úteis**; `"OUTROS VALORES"` em Times 8 mede **25,01 mm**:

```
OUTROS VALORES331.77      <- nome e valor colados
```

Não é caso de borda: `Comp/xNome` é texto livre de até 15 caracteres no XSD, e `AGENDAMENTO` — um dos exemplos citados na documentação do próprio schema — já mede 21,95 mm.

## O que muda

Os dois passam a usar `long_field`, o mesmo recorte por largura medida já usado no DANFE e nos demais nomes do próprio DACTE (`rem_nome`, `dest_nome`, `receb_nome`, `exped_nome`, `tomador_nome`). Nenhum helper novo, nenhuma mudança de geometria.

Único ajuste em relação à #186: o `long_field` do componente passa `font_size=8` explícito. A fonte ambiente ali já era Times 8, então o resultado é idêntico — mas deixa de depender de estado implícito, como o call site do emitente já fazia.

## Vale saber

A caixa do nome do emitente tem 63 mm e comporta ~30 caracteres em Times-Bold 9, de um domínio de 60 (`emit/xNome` `maxLength="60"`). Ou seja, razão social acima de ~30 caracteres passa a sair truncada com "…". É a troca certa — "nome cortado + CNPJ legível" é melhor que "nome inteiro + CNPJ ilegível", e é o que a lib já faz em todo o resto — mas não é de graça, e vai aparecer em bastante CT-e real.

Alargar a caixa não resolve: o retângulo do emitente vai de x=5 a x=72 e o bloco DACTE/MODAL começa em 72. Verticalmente também não sobra: `h_rect=27` e o endereço termina 1 mm antes do fim. As saídas seriam reduzir a fonte quando não couber (a 7pt cabem ~34) ou compactar o bloco de endereço — as duas mudam geometria e ficam para depois.

## Testes

Os testes renderizam o PDF e **leem de volta as posições do texto** do content stream, em vez de checar a chamada de um helper — medem o resultado e continuam válidos se a implementação mudar.

- `test_razao_social_longa_nao_escreve_por_cima_do_cnpj`
- `test_nome_de_componente_longo_nao_invade_a_coluna_do_valor`

Ambos verificados falhando sem a correção. PDFs de referência **inalterados** — nenhuma fixture tem razão social maior que 28 caracteres nem componente com nome largo, que é justamente por que os testes golden nunca pegaram isto.
