### PR TITLE
DACTE: acerta os testes de componentes com a formatação pt-BR

### DIFF
--- a/tests/test_dacte_components.py
+++ b/tests/test_dacte_components.py
@@ -31,6 +31,17 @@ def textos_posicionados(pdf_bytes):
     return achados
 
 
+def valor_impresso(texto):
+    """Converte um valor como saiu no PDF ("1.740,00") em float, ou None.
+
+    Os componentes são desenhados formatados em pt-BR, então ler o número de
+    volta pede o caminho inverso — separador de milhar fora, vírgula por ponto.
+    """
+    if not re.fullmatch(r"\d{1,3}(?:\.\d{3})*,\d{2}", texto):
+        return None
+    return float(texto.replace(".", "").replace(",", "."))
+
+
 @pytest.fixture
 def xml_dacte(load_xml):
     return load_xml("dacte/dacte_test_1.xml")
@@ -56,7 +67,7 @@ def test_componentes_alem_do_nono_aparecem_agregados(xml_dacte):
     # Os 8 primeiros saem individualmente; do 9º ao 12º somam 90+100+110+120.
     assert "COMP 8" in texto
     assert "COMP 9" not in texto
-    assert "420.00" in texto, "a linha agregada não preserva a soma do excedente"
+    assert "420,00" in texto, "a linha agregada não preserva a soma do excedente"
 
 
 def test_nove_componentes_saem_sem_agregacao(xml_dacte):
@@ -85,11 +96,8 @@ def test_soma_dos_componentes_exibidos_bate_com_o_total(xml_dacte):
         # As 3 colunas partilham a baseline, então cada linha do quadro é somada
         # uma vez só — daí o set de baselines em vez de iterar sobre os nomes.
         baselines = {y for y, _, _ in exibidos}
-        total_exibido = sum(
-            to_float(v)
-            for y, _, v in trechos
-            if y in baselines and re.fullmatch(r"\d+\.\d{2}", v)
-        )
+        valores = (valor_impresso(v) for y, _, v in trechos if y in baselines)
+        total_exibido = sum(v for v in valores if v is not None)
 
         esperado = sum(i * 10 for i in range(1, quantidade + 1))
         assert total_exibido == esperado, (


### PR DESCRIPTION
A `main` está vermelha. Dois testes do DACTE quebraram no cruzamento da #191 com a #192 — cada PR passava sozinha, e nenhuma das duas rodou contra a outra depois do merge.

## O que quebrou

A #191 escreveu `tests/test_dacte_components.py` lendo os valores de volta do content stream do PDF **no formato cru do XML**:

```python
assert "420.00" in texto, "a linha agregada não preserva a soma do excedente"
...
total_exibido = sum(
    to_float(v)
    for y, _, v in trechos
    if y in baselines and re.fullmatch(r"\d+\.\d{2}", v)
)
```

A #192 passou a desenhar o `vComp` formatado em pt-BR, então o PDF traz `420,00`. O regex não casa mais com nada, e o `to_float()` — que é o helper do `dacte.py` para ler valor cru de XML — devolve `0.0` para `"1.740,00"`. Daí a soma dar zero:

```
FAILED test_componentes_alem_do_nono_aparecem_agregados
    AssertionError: a linha agregada não preserva a soma do excedente
FAILED test_soma_dos_componentes_exibidos_bate_com_o_total
    AssertionError: com 6 componentes o PDF soma 0, mas o XML declara 210
```

## O que muda

Só o arquivo de teste — o rendering das duas PRs está correto. A leitura de volta passa por um `valor_impresso()` local, que desfaz a formatação em vez de assumir o formato do XML:

```python
def valor_impresso(texto):
    if not re.fullmatch(r"\d{1,3}(?:\.\d{3})*,\d{2}", texto):
        return None
    return float(texto.replace(".", "").replace(",", "."))
```

O separador de milhar precisa entrar no padrão: com 20 componentes a linha agregada sai `1.740,00`, e um `\d+,\d{2}` ingênuo a deixaria de fora da soma — o teste passaria pelo motivo errado, achando que só existem valores de 2 dígitos. O `to_float` continua importado, que o `test_to_float_tolera_valor_ausente_ou_invalido` testa o helper de produção.

## Verificação

- `pytest tests/` → **101 passando**, contra 99 + 2 falhas na `main`
- Os dois testes continuam pegando a regressão que motivou cada PR, conferido desativando cada uma:
  - agregação da #191 desligada (`if len(comp_list) > 9` → `if False`) → os 2 falham
  - `format_number` da #192 removido do desenho → os 2 falham

## Nota

A #193 aparece com CI vermelho por herança destas mesmas 2 falhas, não por nada dela. Mergeando esta primeiro, aquela fica verde.
