### PR TITLE
docs: remove os links para o engenere.one, que saiu do ar

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,4 @@ BrazilFiscalReport is free software licensed under the [LGPL-3.0](https://github
 
 ## Maintainer
 
-Developed and maintained by [Engenere](https://engenere.one/). Issues and pull requests are welcome — see the [contributing guide](https://engenere.github.io/BrazilFiscalReport/contributing/).
-
-[![Engenere](https://storage.googleapis.com/eng-imagens/logo-fundo-preto.webp)](https://engenere.one/)
+Developed and maintained by [Engenere](https://github.com/Engenere). Issues and pull requests are welcome — see the [contributing guide](https://engenere.github.io/BrazilFiscalReport/contributing/).

--- a/docs/about.md
+++ b/docs/about.md
@@ -10,6 +10,4 @@ This is a fork of the [nfe_utils](https://github.com/edsonbernar/nfe_utils) proj
 For questions or support, feel free to open an issue or join the discussions in the repository. Contributions are welcome — see the [contributing guide](contributing.md).
 
 ## Maintainer 🛠️
-Developed and maintained by [Engenere](https://engenere.one/).
-
-[![Engenere](https://storage.googleapis.com/eng-imagens/logo-fundo-preto.webp)](https://engenere.one/)
+Developed and maintained by [Engenere](https://github.com/Engenere).

--- a/docs/about.pt.md
+++ b/docs/about.pt.md
@@ -10,6 +10,4 @@ Este é um fork do projeto [nfe_utils](https://github.com/edsonbernar/nfe_utils)
 Para dúvidas ou suporte, sinta-se à vontade para abrir uma issue ou participar das discussões no repositório. Contribuições são bem-vindas — veja o [guia de contribuição](contributing.md).
 
 ## Mantenedor 🛠️
-Desenvolvido e mantido pela [Engenere](https://engenere.one/).
-
-[![Engenere](https://storage.googleapis.com/eng-imagens/logo-fundo-preto.webp)](https://engenere.one/)
+Desenvolvido e mantido pela [Engenere](https://github.com/Engenere).


### PR DESCRIPTION
O domínio `engenere.one` saiu do ar — não resolve mais em DNS:

```
$ curl -sL -o /dev/null -w "%{http_code}\n" https://engenere.one/
000
$ getent hosts engenere.one
(sem resolução)
```

Ele aparecia no rodapé "Maintainer" de três arquivos: `README.md`, `docs/about.md` e `docs/about.pt.md`.

## O que muda

A atribuição continua — só troca de destino para `https://github.com/Engenere`, que está no ar (200) e é onde o projeto de fato vive:

```diff
-Developed and maintained by [Engenere](https://engenere.one/).
+Developed and maintained by [Engenere](https://github.com/Engenere).
```

**O bloco da logo saiu junto**, e não só porque o link dela era o mesmo site morto: a imagem em si também já não existe.

```
$ curl -sL -o /dev/null -w "%{http_code}\n" \
    https://storage.googleapis.com/eng-imagens/logo-fundo-preto.webp
404
```

Ou seja, o README no GitHub e a página About do site de docs já vinham renderizando imagem quebrada. Se a Engenere tiver uma logo nova em algum lugar vivo, é só me dizer que eu ponho de volta.

## Fora de escopo, de propósito

Os cabeçalhos de copyright do `dacce.py` e do `danfe.py` seguem com `<neto@engenere.one>`:

```python
# Copyright (C) 2024 Engenere - Antônio S. Pereira Neto <neto@engenere.one>
```

É aviso de copyright, registrando quem detinha os direitos em 2024 — não é link de site. Mexer em cabeçalho de licença é outra conversa.

## Verificação

- `grep -rn "engenere.one"` na árvore → só as 2 linhas de copyright acima
- `mkdocs build --strict` passa, nas duas línguas — nenhum link interno quebrou
- `engenere.github.io/BrazilFiscalReport` (o link do contributing guide, logo ao lado) segue vivo e ficou como estava
